### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/httpd-shed.cabal
+++ b/httpd-shed.cabal
@@ -13,7 +13,7 @@ Description:
 Maintainer:     Ganesh Sittampalam
 Copyright:      (c) 2009 Andy Gill
 Build-Type:     Simple
-cabal-version:  >= 1.6
+cabal-version:  >= 1.8
 
 Source-Repository head
   Type:        git


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: httpd-shed.cabal:40:42: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```