### PR TITLE
allow network-3.2

### DIFF
--- a/httpd-shed.cabal
+++ b/httpd-shed.cabal
@@ -43,7 +43,7 @@ Library
   else
      build-depends: network < 2.7
   Build-Depends:
-    network >=2.3     && <3.2,
+    network >=2.3     && <3.3,
     network-uri >=2.5 && <2.7,
     base >= 4.0 && <5.0
   Ghc-Options: -Wall


### PR DESCRIPTION
Hi Ganesh. This was tested using `cabal build -w ghc-9.8.2 -c 'network>=3.2'`. I think a revision would be sufficient since there are no source changes.
